### PR TITLE
Added option to reuse columns on decision trees.

### DIFF
--- a/numl.Tests/Data/TennisWithPlayers.cs
+++ b/numl.Tests/Data/TennisWithPlayers.cs
@@ -1,0 +1,70 @@
+﻿using numl.Data;
+using numl.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace numl.Data
+{
+    public enum NumberOfPlayers
+    {
+        Zero,
+        One,
+        Two,
+        Three,
+        Four
+    }
+
+    public class TennisWithPlayers : Tennis
+    {
+        [Feature]
+        public NumberOfPlayers NumberOfPlayers { get; set; }
+
+
+        public static TennisWithPlayers Make(Outlook outlook, Temperature temperature, Humidity humidity, bool windy, NumberOfPlayers numberOfPlayers, bool play)
+        {
+            return new TennisWithPlayers
+            {
+                Outlook = outlook,
+                Temperature = temperature,
+                Humidity = humidity,
+                Windy = windy,
+                NumberOfPlayers = numberOfPlayers,
+                Play = play
+            };
+        }
+
+        public static Tennis[] GetData()
+        {
+            return new Tennis[]  {
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Hot, Humidity.High, false,NumberOfPlayers.Two, false),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Hot, Humidity.High, true,  NumberOfPlayers.Two,false),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Hot, Humidity.High, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.High, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Cool, Humidity.Normal, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Cool, Humidity.Normal, true, NumberOfPlayers.Four,false),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Cool, Humidity.Normal, true, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Mild, Humidity.High, false, NumberOfPlayers.Four,false),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Cool, Humidity.Normal, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.Normal, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Hot, Humidity.High, true, NumberOfPlayers.Two,false),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Mild, Humidity.High, true, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.Normal, false, NumberOfPlayers.Four,true),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Mild, Humidity.Normal, true, NumberOfPlayers.Four,true),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Mild, Humidity.High, true, NumberOfPlayers.Four,true),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Hot, Humidity.Normal, false, NumberOfPlayers.Two,true),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.High, true, NumberOfPlayers.Two,false),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Cool, Humidity.Normal, false, NumberOfPlayers.Three,false),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.Normal, false, NumberOfPlayers.One,false),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Hot, Humidity.High, false, NumberOfPlayers.One,false),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.High, false, NumberOfPlayers.Three,false),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Hot, Humidity.High, false,NumberOfPlayers.One, false),
+                TennisWithPlayers.Make(Outlook.Sunny, Temperature.Hot, Humidity.High, true,  NumberOfPlayers.One,false),
+                TennisWithPlayers.Make(Outlook.Overcast, Temperature.Hot, Humidity.High, false, NumberOfPlayers.One,false),
+                TennisWithPlayers.Make(Outlook.Rainy, Temperature.Mild, Humidity.High, false, NumberOfPlayers.One,false),
+            };
+        }
+    }
+}

--- a/numl.Tests/SupervisedTests/DecisionTreeTests.cs
+++ b/numl.Tests/SupervisedTests/DecisionTreeTests.cs
@@ -56,6 +56,28 @@ namespace numl.Tests.SupervisedTests
             Assert.IsTrue(t.Play);
         }
 
+        [Test]
+        public void TennisWithPlayers_DT_and_Prediction()
+        {
+            var data = TennisWithPlayers.GetData();
+            var description = Descriptor.Create<TennisWithPlayers>();
+            var generator = new DecisionTreeGenerator(50);
+            var model = generator.Generate(description, data);
+
+            var t = new TennisWithPlayers
+            {
+                Humidity = Humidity.Normal,
+                Outlook = Outlook.Rainy,
+                Temperature = Temperature.Cool,
+                Windy = true,
+                NumberOfPlayers=NumberOfPlayers.Four
+            };
+
+            model.Predict<TennisWithPlayers>(t);
+            Console.Write(model);
+            Assert.IsFalse(t.Play, "Cool, rainy, and windy, we should not be playing double in this!" );
+        }
+
 
         [Test]
         public void Iris_DT_and_Prediction()

--- a/numl.Tests/numl.Tests.csproj
+++ b/numl.Tests/numl.Tests.csproj
@@ -30,9 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\lib\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,6 +55,7 @@
     <Compile Include="Data\Iris.cs" />
     <Compile Include="Data\Student.cs" />
     <Compile Include="Data\Tennis.cs" />
+    <Compile Include="Data\TennisWithPlayers.cs" />
     <Compile Include="Data\ValueObject.cs" />
     <Compile Include="SerializationTests\BaseSerialization.cs" />
     <Compile Include="SerializationTests\DecisionTreeSerializationTests.cs" />
@@ -83,6 +84,7 @@
     <None Include="Data\iris.data">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/numl/Supervised/DecisionTree/DecisionTree.cs
+++ b/numl/Supervised/DecisionTree/DecisionTree.cs
@@ -17,6 +17,7 @@ namespace numl.Supervised.DecisionTree
         public int Depth { get; set; }
         public int Width { get; set; }
         public double Hint { get; set; }
+        public bool AllowColumnReuse { get; set; }
         public Type ImpurityType { get; set; }
 
         private Impurity _impurity;
@@ -36,6 +37,7 @@ namespace numl.Supervised.DecisionTree
             Descriptor = descriptor;
             ImpurityType = typeof(Entropy);
             Hint = double.Epsilon;
+            AllowColumnReuse = true;
         }
 
         public DecisionTreeGenerator(
@@ -43,7 +45,8 @@ namespace numl.Supervised.DecisionTree
             int width = 2,
             Descriptor descriptor = null,
             Type impurityType = null,
-            double hint = double.Epsilon)
+            double hint = double.Epsilon,
+            bool allowColumnReuse = true)
         {
             if (width < 2)
                 throw new InvalidOperationException("Cannot set dt tree width to less than 2!");
@@ -53,6 +56,7 @@ namespace numl.Supervised.DecisionTree
             Width = width;
             ImpurityType = impurityType ?? typeof(Entropy);
             Hint = hint;
+            AllowColumnReuse = allowColumnReuse;
         }
 
         public void SetHint(object o)
@@ -162,6 +166,10 @@ namespace numl.Supervised.DecisionTree
             else
                 node.Edges = egs;
 
+            //Returning this node and moving back up the tree
+            //It possible to reused this column in other branches if desired.
+            if(AllowColumnReuse)
+                used.Remove(col);
             return node;
         }
 
@@ -333,4 +341,8 @@ namespace numl.Supervised.DecisionTree
             serializer.Serialize(writer, Tree, ns);
         }
     }
+
+
+   
+
 }


### PR DESCRIPTION
When building more advanced decision trees I noticed that each column
was only used once in the entire decision and that more accurate
predictions can be attained through reusing columns on different
branches. This comes at a cost of generating a more complex tree so it
was implemented as an optional property on the DecisionTreeGenerator
class.
