### PR TITLE
Removed the changed .Select().Max() b/c the way it was written, it'd …

### DIFF
--- a/numl/Learner.cs
+++ b/numl/Learner.cs
@@ -29,11 +29,7 @@ namespace numl
         /// <returns>Best Model.</returns>
         public static LearningModel Best(this IEnumerable<LearningModel> models)
         {
-            var q = from m in models
-                    where m.Accuracy == (models.Select(s => s.Accuracy).Max())
-                    select m;
-
-            return q.FirstOrDefault();
+            return models.OrderByDescending(m => m.Accuracy).FirstOrDefault();
         }
         /// <summary>
         /// Trains an arbitrary number of models on the provided examples by creating a separation of


### PR DESCRIPTION
…have to iterate through the collection every iteration so it's O(n^2).  Using OrderBy().First() it is O (n log n)