### PR TITLE
Bugfix for subtraction of a vector from a scalar

### DIFF
--- a/Src/numl.Tests/MathTests/VectorTests.cs
+++ b/Src/numl.Tests/MathTests/VectorTests.cs
@@ -282,6 +282,27 @@ namespace numl.Tests.MathTests
                 Assert.AreEqual(1d, h[i], .1);
 
         }
+
+        [Test]
+        public void Vector_And_Scalar_Subtraction_Test()
+        {
+            Vector v = new Vector(new double[] { 1, 2, 3 });
+            double c = 2;
+            Vector expectedDifference = new Vector(new double[] { -1, 0, 1 });
+            Vector difference = v - c;
+
+            Assert.AreEqual(difference, expectedDifference);
+        }
+
+        [Test]
+        public void Vector_And_Scalar_Swapped_Subtraction_Test()
+        {
+            Vector v = new Vector(new double[] { 1, 2, 3 });
+            double c = 2;
+            Vector difference = v - c;
+            Vector swappedDifference = c - v;
+            Assert.AreEqual(difference, -swappedDifference);
+        }
     }
 }
 

--- a/Src/numl/Math/Functions/Cost/LogisticCostFunction.cs
+++ b/Src/numl/Math/Functions/Cost/LogisticCostFunction.cs
@@ -41,7 +41,7 @@ namespace numl.Math.Functions.Cost
 
             Vector slog = s.Copy().Each(v => System.Math.Log(System.Math.Abs(1.0 - v)));
 
-            j = (-1.0 / m) * ( (this.Y.Dot(s.Log())) + (-1.0 * ((1.0 - this.Y).Dot(slog))) );
+            j = (-1.0 / m) * ( (this.Y.Dot(s.Log())) + ((1.0 - this.Y).Dot(slog)) );
 
             if (this.Lambda != 0)
             {

--- a/Src/numl/Math/LinearAlgebra/VectorOps.cs
+++ b/Src/numl/Math/LinearAlgebra/VectorOps.cs
@@ -102,7 +102,11 @@ namespace numl.Math.LinearAlgebra
         /// <returns>The result of the operation.</returns>
         public static Vector operator -(double s, Vector v)
         {
-            return v - s;
+            Vector result = v.Copy();
+            for (int i = 0; i < result.Length; i++)
+                result[i] = s - result[i];
+
+            return result;
         }
         /// <summary>Addition operator.</summary>
         /// <exception cref="InvalidOperationException">Thrown when the requested operation is invalid.</exception>


### PR DESCRIPTION
The result of `constant - vector` operation was equal to `vector - constant`.
I have changed the implementation so that `constant - vector == -(constant - vector)` and added a couple of tests.
The changed operator is only used in LogisticCostFunction.cs (the usage is fixed) and Softmax.cs (it seems that it was not correct before). 