### PR TITLE
Score accuracy was always 0

### DIFF
--- a/Src/numl.Tests/SupervisedTests/BaseSupervised.cs
+++ b/Src/numl.Tests/SupervisedTests/BaseSupervised.cs
@@ -152,6 +152,7 @@ namespace numl.Tests.SupervisedTests
             generator.Descriptor = description;
             var lmodel = Learner.Learn(data, .80, 10, generator);
             var prediction = lmodel.Model.Predict(item);
+            Assert.True(lmodel.Accuracy >= 0.75);
             Assert.True(test(prediction));
         }
 

--- a/Src/numl/Supervised/Score.cs
+++ b/Src/numl/Supervised/Score.cs
@@ -335,7 +335,7 @@ namespace numl.Supervised
             // if the labels are continuous values then calculate accuracy manually
             if (!score._IsBinary)
             {
-                score._totalAccuracy = (predictions.Where((d, idx) => d == actual[idx]).Count() / predictions.Length);
+                score._totalAccuracy = (((double)predictions.Where((d, idx) => d == actual[idx]).Count()) / predictions.Length);
             }
 
             score.RMSE = Score.ComputeRMSE(predictions, actual);


### PR DESCRIPTION
While doing some tests with NaiveBayes models I noticed that the Accuracy was always 0 using the Iris data set. A cast was actually missing.

I also added a basic check of the accuracy in the tests. I hardcoded a minimal accuracy of 0.75 but maybe it would be better for each test to choose its own accuracy. Note that once in a while Tennis_Learner_Tests will fail because its accuracy is 0.66.  Lowering the minimal accuracy in this case will not help because in that case anyways the next assert (`Assert.True(test(prediction));`) will also fail. Maybe the trainingPercentage should be increased ?

Also note that in Linear_Regression_Learner_Test the accuracy check seems wrong. I think it should be 

`Assert.True(model.Accuracy >= 0.8);`

instead of

`Assert.True(0.8 >= model.Accuracy);`

I didn't want to include this change in this pull request as the way the accuracy is computed doesn't make sense for linear regression anyways. The accuracy is 0.0 for this test... Should I open an issue for this ?
