### PR TITLE
Function signature change to accommodate future activations

### DIFF
--- a/Src/numl/Math/Functions/ClippedRectifiedLinear.cs
+++ b/Src/numl/Math/Functions/ClippedRectifiedLinear.cs
@@ -39,12 +39,12 @@ namespace numl.Math.Functions
         }
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed clipped rectifier output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            return (x > 0d && x < MaxValue ? 1 : 0);
+            return (x > 0d && x < MaxValue ? 1d : 0d);
         }
     }
 }

--- a/Src/numl/Math/Functions/Function.cs
+++ b/Src/numl/Math/Functions/Function.cs
@@ -36,24 +36,26 @@ namespace numl.Math.Functions
         public abstract double Compute(double x);
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
-        public abstract double Derivative(double x, bool cached = false);
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed output of the function.</param>
+        /// <returns>Double.</returns>
+        public abstract double Derivative(double x, double y);
 
         /// <summary>Computes the given x coordinate.</summary>
         /// <param name="x">The Vector to process.</param>
         /// <returns>A Vector.</returns>
-        public Vector Compute(Vector x)
+        public virtual Vector Compute(Vector x)
         {
             return x.Calc(d => Compute(d));
         }
+
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        public Vector Derivative(Vector x, bool cached = false)
+        /// <param name="x">The input to process.</param>
+        /// <param name="y">Precomputed output of the function.</param>
+        /// <returns>Vector.</returns>
+        public virtual Vector Derivative(Vector x, Vector y)
         {
-            return x.Calc(d => Derivative(d, cached));
+            return x.Each((xi, idx) => Derivative(xi, y[idx]));
         }
 
         /// <summary>

--- a/Src/numl/Math/Functions/IFunction.cs
+++ b/Src/numl/Math/Functions/IFunction.cs
@@ -19,15 +19,15 @@ namespace numl.Math.Functions
         double Maximum { get; }
 
         /// <summary>Computes the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
+        /// <param name="x">The input to process.</param>
+        /// <returns>Double.</returns>
         double Compute(double x);
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        double Derivative(double x, bool cached = false);
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed output of the function.</param>
+        /// <returns>Double.</returns>
+        double Derivative(double x, double y);
 
         /// <summary>
         /// Computes and condenses the given x coordinate.
@@ -42,8 +42,9 @@ namespace numl.Math.Functions
         Vector Compute(Vector x);
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
-        Vector Derivative(Vector x, bool cached = false);
+        /// <param name="x">The input to process.</param>
+        /// <param name="y">Precomputed output of the function.</param>
+        /// <returns>Vector.</returns>
+        Vector Derivative(Vector x, Vector y);
     }
 }

--- a/Src/numl/Math/Functions/Ident.cs
+++ b/Src/numl/Math/Functions/Ident.cs
@@ -23,13 +23,14 @@ namespace numl.Math.Functions
         {
             return x;
         }
+
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed output of the function.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            return 1;
+            return 1d;
         }
     }
 }

--- a/Src/numl/Math/Functions/Logistic.cs
+++ b/Src/numl/Math/Functions/Logistic.cs
@@ -18,19 +18,20 @@ namespace numl.Math.Functions
         public override double Maximum { get { return 1; } }
 
         /// <summary>Computes the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
+        /// <param name="x">The value to process.</param>
+        /// <returns>A double.</returns>
         public override double Compute(double x)
         {
             return 1d / (1d + exp(-x));
         }
+
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed logistic output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            var c = (cached ? x : Compute(x));
-            return c * (1d - c);
+            return y * (1d - y);
         }
     }
 }

--- a/Src/numl/Math/Functions/RectifiedLinear.cs
+++ b/Src/numl/Math/Functions/RectifiedLinear.cs
@@ -26,12 +26,12 @@ namespace numl.Math.Functions
         }
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The value to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A double.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed rectifier output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            return (x > 0d ? 1 : 0);
+            return (x > 0d ? 1d : 0d);
         }
     }
 }

--- a/Src/numl/Math/Functions/Softmax.cs
+++ b/Src/numl/Math/Functions/Softmax.cs
@@ -7,66 +7,64 @@ namespace numl.Math.Functions
     /// <summary>
     /// Softmax function
     /// </summary>
-    public class Softmax : IFunction
+    public class Softmax : Function
     {
         /// <summary>
         /// Returns the minimum value from the function curve, equal to 0.0.
         /// </summary>
-        public double Minimum { get { return 0; } }
+        public override double Minimum => 0d;
 
         /// <summary>
         /// Returns the maximum value from the function curve, equal to 1.0.
         /// </summary>
-        public double Maximum { get { return 1; } }
+        public override double Maximum => 1d;
 
         /// <summary>
         /// Returns a softmax function vector from the supplied inputs.
         /// </summary>
         /// <param name="x"></param>
         /// <returns></returns>
-        public Vector Compute(Vector x)
+        public override Vector Compute(Vector x)
         {
             double max = x.Max();
             Vector softmax = Vector.Exp(x - max);
 
             double sum = softmax.Sum();
 
-            softmax = (softmax / sum); 
+            softmax = (softmax / sum);
 
             return softmax;
         }
 
-        /// <summary>
-        /// Not used.
-        /// </summary>
-        /// <param name="x"></param>
-        /// <returns></returns>
-        public double Compute(double x)
+        /// <summary>Computes the given x coordinate.</summary>
+        /// <param name="x">The value to process.</param>
+        /// <returns>A double.</returns>
+        public override double Compute(double x)
         {
-            throw new NotImplementedException();
+            return exp(x);
         }
 
-        /// <summary>
-        /// Computes the derivation of the softmax function.
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns></returns>
-        public Vector Derivative(Vector x, bool cached = false)
+        /// <summary>Computes the derivation of the softmax function.</summary>
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed softmax output.</param>
+        /// <returns>Double.</returns>
+        public override Vector Derivative(Vector x, Vector y)
         {
-            Vector d = (cached ? x : Compute(x));
-            return d * (1d - d);
+            var Y = y.ToMatrix();
+            var J = Y.T * Y;
+            var R = (Y.T * (1.0 - Y));
+            var I = Matrix.Identity(J.Rows);
+            var D = R.Each((v, i, j) => (i == j) ? v * I[i, j] : J[i, j]);
+            return D.Sum(VectorType.Row);
         }
 
-        /// <summary>
-        /// Not used.
-        /// </summary>
-        /// <param name="x"></param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns></returns>
-        public double Derivative(double x, bool cache = false)
+        /// <summary>Derivatives the given x coordinate.</summary>
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed softmax output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            throw new NotImplementedException();
+            return y - (1.0 - y);
         }
 
         /// <summary>
@@ -74,7 +72,7 @@ namespace numl.Math.Functions
         /// </summary>
         /// <param name="x">Vector.</param>
         /// <returns>Double.</returns>
-        public double Minimize(Vector x)
+        public override double Minimize(Vector x)
         {
             return Compute(x).MaxIndex();
         }

--- a/Src/numl/Math/Functions/Softplus.cs
+++ b/Src/numl/Math/Functions/Softplus.cs
@@ -31,16 +31,13 @@ namespace numl.Math.Functions
             return System.Math.Log(1d + exp(x));
         }
 
-        /// <summary>
-        /// Derivatives the given x coordinate.
-        /// </summary>
-        /// <param name="x">The double to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
+        /// <summary>Derivatives the given x coordinate.</summary>
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed softplus output.</param>
         /// <returns>Double.</returns>
-        public override double Derivative(double x, bool cached = false)
+        public override double Derivative(double x, double y)
         {
-            double c = (cached ? x : Compute(x));
-            return 1.0 + (1.0 / (-exp(c)));
+            return 1d / (1d + exp(-x));
         }
     }
 }

--- a/Src/numl/Math/Functions/SteepLogistic.cs
+++ b/Src/numl/Math/Functions/SteepLogistic.cs
@@ -24,14 +24,14 @@ namespace numl.Math.Functions
         {
             return 1d / (1d + exp(-System.Math.PI * x));
         }
+
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed softplus output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            var c = (cached ? x : Compute(x));
-            return System.Math.PI * c * (1d - c);
+            return System.Math.PI * y * (1d - y);
         }
     }
 }

--- a/Src/numl/Math/Functions/Swish.cs
+++ b/Src/numl/Math/Functions/Swish.cs
@@ -31,12 +31,12 @@ namespace numl.Math.Functions
         }
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed swish output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            var c = (cached ? x : Compute(x));
-            return c + Sigmoid(x) * (1d - c);
+            return y + Sigmoid(x) * (1d - y);
         }
     }
 }

--- a/Src/numl/Math/Functions/Tanh.cs
+++ b/Src/numl/Math/Functions/Tanh.cs
@@ -26,13 +26,12 @@ namespace numl.Math.Functions
         }
 
         /// <summary>Derivatives the given x coordinate.</summary>
-        /// <param name="x">The Vector to process.</param>
-        /// <param name="cached">If True, uses the previously computed activation.</param>
-        /// <returns>A Vector.</returns>
-        public override double Derivative(double x, bool cached = false)
+        /// <param name="x">The input to the function.</param>
+        /// <param name="y">Precomputed softplus output.</param>
+        /// <returns>Double.</returns>
+        public override double Derivative(double x, double y)
         {
-            double c = (cached ? x : Compute(x));
-            return 1 - pow(x, 2);
+            return 1d - pow(y, 2);
         }
     }
 }

--- a/Src/numl/Supervised/NeuralNetwork/Encoders/AutoencoderNeuron.cs
+++ b/Src/numl/Supervised/NeuralNetwork/Encoders/AutoencoderNeuron.cs
@@ -58,7 +58,7 @@ namespace numl.Supervised.NeuralNetwork.Encoders
             {
                 if (In.Count > 0 && Out.Count > 0)
                 {
-                    double hp = this.ActivationFunction.Derivative(this.Input);
+                    double hp = this.ActivationFunction.Derivative(this.Input, this.Output);
                     double divergence = AutoencoderNeuron.Divergence((double)properties[nameof(AutoencoderGenerator.Sparsity)], 
                                                                      (double)properties[nameof(AutoencoderGenerator.SparsityWeight)], 
                                                                      this.Mu);

--- a/Src/numl/Supervised/NeuralNetwork/Neuron.cs
+++ b/Src/numl/Supervised/NeuralNetwork/Neuron.cs
@@ -154,7 +154,7 @@ namespace numl.Supervised.NeuralNetwork
             {
                 if (In.Count > 0 && Out.Count > 0)
                 {
-                    double hp = this.ActivationFunction.Derivative(this.Input, false);
+                    double hp = this.ActivationFunction.Derivative(this.Input, this.Output);
                     delta = Out.Sum(e => e.Weight * t) * hp;
                 }
 

--- a/Src/numl/Supervised/NeuralNetwork/Recurrent/RecurrentNeuron.cs
+++ b/Src/numl/Supervised/NeuralNetwork/Recurrent/RecurrentNeuron.cs
@@ -214,13 +214,13 @@ namespace numl.Supervised.NeuralNetwork.Recurrent
 
                     // dyhh = delta(htm1) = 1-Z, dyhz = delta(Z) = HtP
                     double dyhh = (1.0 - z), dyhz = this.StatesHP[timestep];
-                    double dHtP = this.ActivationFunction.Derivative(input + r * (htm1 * this.Hh));
+                    double dHtP = this.ActivationFunction.Derivative(input + r * (htm1 * this.Hh), this.HtP);
 
                     this.DHh = ((dHtP * dyhh) * htm1);
                     this.DHh = this.DeltaH[timestep] = this.DeltaH.GetValueOrDefault(timestep + 1, 0) + this.DHh;
 
-                    double dr = this.ResetGate.Derivative((this.Rx * input) + (this.Rh * ht) + this.Rb);
-                    double dz = this.UpdateGate.Derivative((this.Zx * input) + (this.Zh * ht) + this.Zb);
+                    double dr = this.ResetGate.Derivative((this.Rx * input) + (this.Rh * ht) + this.Rb, this.R);
+                    double dz = this.UpdateGate.Derivative((this.Zx * input) + (this.Zh * ht) + this.Zb, this.Z);
 
                     this.DRx = (seqmod * (dr * input)); this.DRh = (seqmod * (dr * ht));
                     this.DZx = (seqmod * (dz * input)); this.DZh = (seqmod * (dz * ht));


### PR DESCRIPTION
Changed function signature to allow for future activations.

_from_
```
public override double Derivative(double x, bool cached = false) 
```
_to_
```
public override double Derivative(double x, double y) 
```

This allows for special case derivatives like softmax which requires multiple participating inputs.